### PR TITLE
Update Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,4 +5,5 @@ group :jekyll_plugins do
     gem 'jekyll-paginate'
     gem 'jekyll-scholar'
     gem 'jemoji'
+    gem 'unicode_utils'
 end


### PR DESCRIPTION
Using recent versions of ruby, bundler on Ubuntu 16.04 results in the following bug. (TL;DR: 'unicode_utils' is needed as a dependency). Else, 'bundle exec jekyll serve' fails with the following error message

CiteProc requires the `unicode_utils` or `unicode` Gem on Ruby 2.3
/var/lib/gems/2.3.0/gems/bundler-1.16.1/lib/bundler/runtime.rb:84:in `rescue in block (2 levels) in require': There was an error while trying to load the gem 'jekyll-scholar'. (Bundler::GemRequireError)
Gem Load Error is: undefined method `upcase' for module `CiteProc'
Backtrace for gem load error is:
/var/lib/gems/2.3.0/gems/citeproc-1.0.9/lib/citeproc/compatibility.rb:63:in `module_function'
/var/lib/gems/2.3.0/gems/citeproc-1.0.9/lib/citeproc/compatibility.rb:63:in `<module:CiteProc>'
/var/lib/gems/2.3.0/gems/citeproc-1.0.9/lib/citeproc/compatibility.rb:62:in `<top (required)>'
/var/lib/gems/2.3.0/gems/citeproc-1.0.9/lib/citeproc.rb:32:in `require'
/var/lib/gems/2.3.0/gems/citeproc-1.0.9/lib/citeproc.rb:32:in `<top (required)>'
/var/lib/gems/2.3.0/gems/citeproc-ruby-1.1.10/lib/citeproc/ruby.rb:4:in `require'
/var/lib/gems/2.3.0/gems/citeproc-ruby-1.1.10/lib/citeproc/ruby.rb:4:in `<top (required)>'
/var/lib/gems/2.3.0/gems/jekyll-scholar-5.13.0/lib/jekyll/scholar.rb:7:in `require'
/var/lib/gems/2.3.0/gems/jekyll-scholar-5.13.0/lib/jekyll/scholar.rb:7:in `<top (required)>'
/var/lib/gems/2.3.0/gems/jekyll-scholar-5.13.0/lib/jekyll-scholar.rb:1:in `require'
/var/lib/gems/2.3.0/gems/jekyll-scholar-5.13.0/lib/jekyll-scholar.rb:1:in `<top (required)>'
/var/lib/gems/2.3.0/gems/bundler-1.16.1/lib/bundler/runtime.rb:81:in `require'
/var/lib/gems/2.3.0/gems/bundler-1.16.1/lib/bundler/runtime.rb:81:in `block (2 levels) in require'
/var/lib/gems/2.3.0/gems/bundler-1.16.1/lib/bundler/runtime.rb:76:in `each'
/var/lib/gems/2.3.0/gems/bundler-1.16.1/lib/bundler/runtime.rb:76:in `block in require'
/var/lib/gems/2.3.0/gems/bundler-1.16.1/lib/bundler/runtime.rb:65:in `each'
/var/lib/gems/2.3.0/gems/bundler-1.16.1/lib/bundler/runtime.rb:65:in `require'
/var/lib/gems/2.3.0/gems/bundler-1.16.1/lib/bundler.rb:114:in `require'
/var/lib/gems/2.3.0/gems/jekyll-3.7.3/lib/jekyll/plugin_manager.rb:51:in `require_from_bundler'
/var/lib/gems/2.3.0/gems/jekyll-3.7.3/exe/jekyll:11:in `<top (required)>'
/usr/local/bin/jekyll:23:in `load'
/usr/local/bin/jekyll:23:in `<main>'
Bundler Error Backtrace:
	from /var/lib/gems/2.3.0/gems/bundler-1.16.1/lib/bundler/runtime.rb:80:in `block (2 levels) in require'
	from /var/lib/gems/2.3.0/gems/bundler-1.16.1/lib/bundler/runtime.rb:76:in `each'
	from /var/lib/gems/2.3.0/gems/bundler-1.16.1/lib/bundler/runtime.rb:76:in `block in require'
	from /var/lib/gems/2.3.0/gems/bundler-1.16.1/lib/bundler/runtime.rb:65:in `each'
	from /var/lib/gems/2.3.0/gems/bundler-1.16.1/lib/bundler/runtime.rb:65:in `require'
	from /var/lib/gems/2.3.0/gems/bundler-1.16.1/lib/bundler.rb:114:in `require'
	from /var/lib/gems/2.3.0/gems/jekyll-3.7.3/lib/jekyll/plugin_manager.rb:51:in `require_from_bundler'
	from /var/lib/gems/2.3.0/gems/jekyll-3.7.3/exe/jekyll:11:in `<top (required)>'
	from /usr/local/bin/jekyll:23:in `load'
	from /usr/local/bin/jekyll:23:in `<main>'